### PR TITLE
feat: 치안 뉴스 API 페이지네이션 및 category_tag 필드 추가

### DIFF
--- a/analysis/src/main/java/ziply/analysis/controller/RouteAnalysisController.java
+++ b/analysis/src/main/java/ziply/analysis/controller/RouteAnalysisController.java
@@ -53,16 +53,23 @@ public class RouteAnalysisController {
      * 탐색카드 내 각 집의 동(법정동) 기반 치안 뉴스 집계 조회.
      *
      * @param period 조회 기간 (개월): 3, 6, 12 (기본값 3)
+     * @param page   페이지 번호 (0-based, 기본값 0)
+     * @param size   페이지당 항목 수 (기본값 10, 최대 50)
      */
     @GetMapping("/news/{searchCardId}")
     public ResponseEntity<List<SafetyNewsResponse>> getSafetyNews(
             @PathVariable UUID searchCardId,
             @AuthenticationPrincipal Long userId,
-            @RequestParam(defaultValue = "3") int period) {
+            @RequestParam(defaultValue = "3") int period,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
         if (period != 3 && period != 6 && period != 12) {
             return ResponseEntity.badRequest().build();
         }
-        return ResponseEntity.ok(safetyNewsService.getNewsAnalysis(searchCardId, userId, period));
+        if (size < 1 || size > 50) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(safetyNewsService.getNewsAnalysis(searchCardId, userId, period, page, size));
     }
 
     /**

--- a/analysis/src/main/java/ziply/analysis/domain/SafetyNews.java
+++ b/analysis/src/main/java/ziply/analysis/domain/SafetyNews.java
@@ -27,6 +27,9 @@ public class SafetyNews {
     @Column(name = "category_level", nullable = false)
     private Integer categoryLevel;   // 1, 2, 3
 
+    @Column(name = "category_tag", length = 30)
+    private String categoryTag;      // 중분류 (예: "재산 범죄", "대인 강력")
+
     @Column(name = "region_name")
     private String regionName;       // 예: 상도동, 동작구
 

--- a/analysis/src/main/java/ziply/analysis/dto/response/SafetyNewsResponse.java
+++ b/analysis/src/main/java/ziply/analysis/dto/response/SafetyNewsResponse.java
@@ -1,6 +1,6 @@
 package ziply.analysis.dto.response;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,8 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * GET /api/v1/analysis/news/{searchCardId}?period=3 응답 DTO.
- * 탐색카드 내 각 집(houseId)의 동별 치안 뉴스 집계 결과.
+ * GET /api/v1/analysis/news/{searchCardId}?period=3&page=0&size=10 응답 DTO.
+ * 탐색카드 내 각 집(houseId)의 동별 치안 뉴스 집계 결과 (페이지네이션 포함).
  */
 @Getter
 @Builder
@@ -17,29 +17,31 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SafetyNewsResponse {
 
-    private Long houseId;
-    private String label;          // A, B, C ...
-    private String regionName;     // 법정동 이름 (예: 상도동)
-    private int period;            // 조회 기간 (개월)
+    private String label;           // A, B, C ...
+    private String regionName;      // 법정동 이름 (예: 상도동)
 
-    private int level1Count;       // 생활 불편
-    private int level2Count;       // 안전 불안
-    private int level3Count;       // 신변 위협
-    private int totalCount;
+    private int level1Count;        // 생활 불편
+    private int level2Count;        // 안전 불안
+    private int level3Count;        // 신변 위협
 
-    private String message;        // 요약 메시지
+    private String message;         // 요약 메시지
 
-    private List<NewsItem> recentNews;   // 최신 기사 목록 (최대 5건)
+    private List<NewsItem> recentNews;   // 페이지네이션된 기사 목록
+
+    private int page;               // 현재 페이지 (0-based)
+    private int size;               // 페이지당 항목 수
+    private long totalCount;        // 전체 기사 수
+    private int totalPages;         // 전체 페이지 수
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class NewsItem {
-        private Long id;
         private String title;
-        private int categoryLevel;
-        private LocalDateTime publishedAt;
+        private String categoryLevel;   // "생활 불편 / 무질서" | "안전 불안 / 재산 위협" | "신변 위협 / 강력 범죄"
+        private String categoryTag;     // 중분류 (예: "재산 범죄", "대인 강력") — 재분류 전 null
+        private LocalDate publishedAt;
         private String contentUrl;
         private String summary;
     }

--- a/analysis/src/main/java/ziply/analysis/repository/SafetyNewsRepository.java
+++ b/analysis/src/main/java/ziply/analysis/repository/SafetyNewsRepository.java
@@ -2,6 +2,8 @@ package ziply.analysis.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,8 +12,7 @@ import ziply.analysis.domain.SafetyNews;
 public interface SafetyNewsRepository extends JpaRepository<SafetyNews, Long> {
 
     /**
-     * 동 이름과 기간으로 치안 뉴스 조회.
-     * 동 이름은 LIKE로 매칭 (예: "상도동" → "상도1동", "상도2동" 포함)
+     * 동 이름과 기간으로 치안 뉴스 조회 (전체 목록, 레벨 집계용).
      */
     @Query("SELECT s FROM SafetyNews s " +
            "WHERE s.regionName LIKE %:regionName% " +
@@ -20,6 +21,17 @@ public interface SafetyNewsRepository extends JpaRepository<SafetyNews, Long> {
     List<SafetyNews> findByRegionAndPeriod(
             @Param("regionName") String regionName,
             @Param("since") LocalDateTime since);
+
+    /**
+     * 동 이름과 기간으로 치안 뉴스 페이지네이션 조회.
+     */
+    @Query("SELECT s FROM SafetyNews s " +
+           "WHERE s.regionName LIKE %:regionName% " +
+           "AND s.publishedAt >= :since")
+    Page<SafetyNews> findByRegionAndPeriodPageable(
+            @Param("regionName") String regionName,
+            @Param("since") LocalDateTime since,
+            Pageable pageable);
 
     /**
      * 레벨별 개수 집계용 (동 이름 + 기간)

--- a/analysis/src/main/java/ziply/analysis/service/SafetyNewsService.java
+++ b/analysis/src/main/java/ziply/analysis/service/SafetyNewsService.java
@@ -2,7 +2,6 @@ package ziply.analysis.service;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +9,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -30,7 +32,13 @@ import org.springframework.beans.factory.annotation.Value;
 @RequiredArgsConstructor
 public class SafetyNewsService {
 
-    private static final int MAX_RECENT_NEWS = 5;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+
+    private static final Map<Integer, String> LEVEL_NAME = Map.of(
+        1, "생활 불편 / 무질서",
+        2, "안전 불안 / 재산 위협",
+        3, "신변 위협 / 강력 범죄"
+    );
 
     private final SafetyNewsRepository safetyNewsRepository;
     private final HouseRouteAnalysisRepository routeAnalysisRepository;
@@ -47,7 +55,7 @@ public class SafetyNewsService {
      * @param period       조회 기간 (개월): 3, 6, 12
      */
     @Transactional(readOnly = true)
-    public List<SafetyNewsResponse> getNewsAnalysis(UUID searchCardId, Long userId, int period) {
+    public List<SafetyNewsResponse> getNewsAnalysis(UUID searchCardId, Long userId, int period, int page, int size) {
         checkCardOwner(searchCardId, userId);
 
         // HouseAnalysis에서 searchCard 소속 집 목록 및 regionName 조회
@@ -82,17 +90,17 @@ public class SafetyNewsService {
                         return buildEmptyResponse(houseId, label, period);
                     }
 
-                    return buildNewsResponse(houseId, label, regionName, period, since);
+                    return buildNewsResponse(houseId, label, regionName, period, since, page, size);
                 })
                 .collect(Collectors.toList());
     }
 
     private SafetyNewsResponse buildNewsResponse(Long houseId, String label, String regionName,
-                                                  int period, LocalDateTime since) {
-        List<SafetyNews> newsList = safetyNewsRepository.findByRegionAndPeriod(regionName, since);
-
+                                                  int period, LocalDateTime since, int page, int size) {
+        // 레벨 카운트는 전체 조회
+        List<SafetyNews> allNews = safetyNewsRepository.findByRegionAndPeriod(regionName, since);
         int level1 = 0, level2 = 0, level3 = 0;
-        for (SafetyNews n : newsList) {
+        for (SafetyNews n : allNews) {
             switch (n.getCategoryLevel()) {
                 case 1 -> level1++;
                 case 2 -> level2++;
@@ -101,13 +109,16 @@ public class SafetyNewsService {
         }
         int total = level1 + level2 + level3;
 
-        List<NewsItem> recent = newsList.stream()
-                .limit(MAX_RECENT_NEWS)
+        // 페이지네이션 뉴스 조회 (최신순)
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "publishedAt"));
+        Page<SafetyNews> newsPage = safetyNewsRepository.findByRegionAndPeriodPageable(regionName, since, pageable);
+
+        List<NewsItem> recent = newsPage.getContent().stream()
                 .map(n -> NewsItem.builder()
-                        .id(n.getId())
                         .title(n.getTitle())
-                        .categoryLevel(n.getCategoryLevel())
-                        .publishedAt(n.getPublishedAt())
+                        .categoryLevel(LEVEL_NAME.getOrDefault(n.getCategoryLevel(), "알 수 없음"))
+                        .categoryTag(n.getCategoryTag())
+                        .publishedAt(n.getPublishedAt().toLocalDate())
                         .contentUrl(n.getContentUrl())
                         .summary(n.getSummary())
                         .build())
@@ -116,28 +127,28 @@ public class SafetyNewsService {
         String message = buildMessage(regionName, period, level1, level2, level3, total);
 
         return SafetyNewsResponse.builder()
-                .houseId(houseId)
                 .label(label)
                 .regionName(regionName)
-                .period(period)
                 .level1Count(level1)
                 .level2Count(level2)
                 .level3Count(level3)
-                .totalCount(total)
                 .message(message)
                 .recentNews(recent)
+                .page(newsPage.getNumber())
+                .size(newsPage.getSize())
+                .totalCount(newsPage.getTotalElements())
+                .totalPages(newsPage.getTotalPages())
                 .build();
     }
 
     private SafetyNewsResponse buildEmptyResponse(Long houseId, String label, int period) {
         return SafetyNewsResponse.builder()
-                .houseId(houseId)
                 .label(label)
                 .regionName(null)
-                .period(period)
-                .level1Count(0).level2Count(0).level3Count(0).totalCount(0)
+                .level1Count(0).level2Count(0).level3Count(0)
                 .message("이 집의 지역 정보를 확인할 수 없어 치안 뉴스를 불러오지 못했어요.")
                 .recentNews(Collections.emptyList())
+                .page(0).size(0).totalCount(0).totalPages(0)
                 .build();
     }
 

--- a/news-collector/claude_classifier.py
+++ b/news-collector/claude_classifier.py
@@ -1,13 +1,18 @@
 """
 Ziply 치안 뉴스 수집기 - OpenAI API 분류 모듈
-뉴스 제목 + 설명을 기반으로 치안 위험도 레벨(1~3) 또는 '기타'를 분류한다.
+뉴스 제목 + 설명을 기반으로 치안 위험도 레벨(1~3) + 중분류 태그를 분류한다.
 """
 
 import json
 import logging
+import time
 from typing import Literal
 
-from openai import OpenAI
+from openai import OpenAI, RateLimitError
+
+# Rate limit 재시도 설정
+_RATE_LIMIT_RETRIES = 4          # 최대 재시도 횟수
+_RATE_LIMIT_BACKOFF = [60, 120, 240, 480]  # 대기 시간 (초)
 
 from config import OPENAI_API_KEY, OPENAI_MODEL
 
@@ -15,67 +20,197 @@ logger = logging.getLogger(__name__)
 
 ClassificationResult = Literal[1, 2, 3, "기타"]
 
+_VALID_LEVELS = (1, 2, 3, "기타")
 
-# ── 시스템 프롬프트 ────────────────────────────────────────
+# 레벨별 허용 태그
+_VALID_TAGS: dict[int, set[str]] = {
+    1: {"기초질서 위반", "인근 소란", "유해 환경"},
+    2: {"대인 불안", "재산 범죄", "질서 위반", "시설 위반"},
+    3: {"침입 범죄", "대인 강력", "성범죄", "사회 재난"},
+}
 
-SYSTEM_PROMPT = """\
+# 레벨에 맞지 않는 태그 → 가장 가까운 유효 태그로 교정
+_TAG_RECOMMEND: dict[tuple[int, str], str] = {
+    # Level 3 태그가 Level 2에 배정된 경우
+    (2, "대인 강력"): "대인 불안",
+    (2, "성범죄"):    "대인 불안",
+    (2, "침입 범죄"): "재산 범죄",
+    (2, "사회 재난"): "질서 위반",
+    # Level 3 태그가 Level 1에 배정된 경우
+    (1, "대인 강력"): "인근 소란",
+    (1, "성범죄"):    "인근 소란",
+    (1, "침입 범죄"): "유해 환경",
+    (1, "사회 재난"): "유해 환경",
+    # Level 2 태그가 Level 3에 배정된 경우
+    (3, "재산 범죄"): "침입 범죄",
+    (3, "대인 불안"): "대인 강력",
+    (3, "질서 위반"): "사회 재난",
+    (3, "시설 위반"): "침입 범죄",
+    # Level 2 태그가 Level 1에 배정된 경우
+    (1, "대인 불안"): "인근 소란",
+    (1, "재산 범죄"): "유해 환경",
+    (1, "질서 위반"): "기초질서 위반",
+    (1, "시설 위반"): "유해 환경",
+    # Level 1 태그가 Level 2에 배정된 경우
+    (2, "기초질서 위반"): "질서 위반",
+    (2, "인근 소란"):    "대인 불안",
+    (2, "유해 환경"):    "질서 위반",
+    # Level 1 태그가 Level 3에 배정된 경우
+    (3, "기초질서 위반"): "사회 재난",
+    (3, "인근 소란"):    "대인 강력",
+    (3, "유해 환경"):    "사회 재난",
+    # 완전히 잘못된 태그 (LLM 할루시네이션)
+    (1, "부동산 범죄"): "유해 환경",
+    (2, "부동산 범죄"): "재산 범죄",
+    (3, "부동산 범죄"): "침입 범죄",
+    # 오탈자 / 변형 태그
+    (2, "대인지원"):   "대인 불안",
+    (1, "대인지원"):   "인근 소란",
+    (3, "대인지원"):   "대인 강력",
+    (1, "사고"):       "기초질서 위반",
+    (2, "사고"):       "질서 위반",
+    (3, "사고"):       "사회 재난",
+    (1, "명예훼손"):   "인근 소란",
+    (2, "명예훼손"):   "질서 위반",
+    (3, "명예훼손"):   "대인 강력",
+    (1, "마약 관련"):  "유해 환경",
+    (2, "마약 관련"):  "질서 위반",
+    (3, "마약 관련"):  "사회 재난",
+    (1, "조율 위반"):   "기초질서 위반",
+    (2, "조율 위반"):   "질서 위반",
+    (3, "조율 위반"):   "사회 재난",
+    (1, "실시설 위반"): "유해 환경",
+    (2, "실시설 위반"): "시설 위반",
+    (3, "실시설 위반"): "침입 범죄",
+    (1, "뇌물공여"):         "유해 환경",
+    (2, "뇌물공여"):         "질서 위반",
+    (3, "뇌물공여"):         "사회 재난",
+    (1, "마약 의심 행위"):   "유해 환경",
+    (2, "마약 의심 행위"):   "질서 위반",
+    (3, "마약 의심 행위"):   "사회 재난",
+    (1, "청소년 비행"):             "유해 환경",
+    (2, "청소년 비행"):             "질서 위반",
+    (3, "청소년 비행"):             "사회 재난",
+    (1, "청소년 비행(흡연/모임)"): "유해 환경",
+    (2, "청소년 비행(흡연/모임)"): "질서 위반",
+    (3, "청소년 비행(흡연/모임)"): "사회 재난",
+    (1, "강도"):                      "유해 환경",
+    (2, "강도"):                      "재산 범죄",
+    (3, "강도"):                      "침입 범죄",
+    (2, "음주운전 사고 빈발 구역"):   "질서 위반",
+    (1, "음주운전 사고 빈발 구역"):   "기초질서 위반",
+    (3, "음주운전 사고 빈발 구역"):   "사회 재난",
+    (1, "층간소음 분쟁"):             "인근 소란",
+    (2, "층간소음 분쟁"):             "대인 불안",
+    (3, "층간소음 분쟁"):             "대인 강력",
+    (1, "아동 대상 범죄"):            "유해 환경",
+    (2, "아동 대상 범죄"):            "대인 불안",
+    (3, "아동 대상 범죄"):            "성범죄",
+    # 레벨 대분류명을 태그로 잘못 사용한 경우
+    (1, "생활 불편"):              "기초질서 위반",
+    (1, "생활 불편 / 무질서"):     "기초질서 위반",
+    (2, "안전 불안"):              "대인 불안",
+    (2, "안전 불안 / 재산 위협"):  "대인 불안",
+    (3, "신변 위협"):              "대인 강력",
+    (3, "신변 위협 / 강력 범죄"):  "대인 강력",
+}
+
+# ── 분류 기준 (프롬프트 공통 블록) ─────────────────────────
+
+_CRITERIA = """\
+## 분류 기준
+
+### Level 1 — 생활 불편 / 무질서
+- **기초질서 위반**: 노상방뇨, 오물 투기, 쓰레기 무단 투기, 무단 횡단
+- **인근 소란**: 고성방가, 공공장소 구걸, 노상 잠자기, 층간소음 분쟁
+- **유해 환경**: 불법 전단지 배포, 청소년 비행(흡연/모임), 금연 구역 내 흡연
+
+### Level 2 — 안전 불안 / 재산 위협
+- **대인 불안**: 취객 난동, 위협적인 접근, 스토킹 전조 행위, 행패 소란
+- **재산 범죄**: 자전거/오토바이 절도, 택배 도난, 차량 털이, 기물 파손(그래피티 등)
+- **질서 위반**: 불법 도박(도박장 운영), 음주운전 사고 빈발 구역, 마약 의심 행위
+- **시설 위반**: 무단 주거지 출입(공용부), 방범창 파손
+
+### Level 3 — 신변 위협 / 강력 범죄
+- **침입 범죄**: 주거 침입, 강도, 빈집털이(침입형 절도)
+- **대인 강력**: 폭행 및 상해, 살인, 납치, 감금
+- **성범죄**: 성폭행, 강제추행, 디지털 성범죄(몰카 등), 아동 대상 범죄
+- **사회 재난**: 방화(불지르기), 흉기 난동, 보복 범죄
+
+### 기타
+부동산 광고, 맛집 홍보, 행정 공지, 교통 정보, 스포츠 기사 등
+치안·범죄·사고와 무관한 콘텐츠"""
+
+# ── 단건 시스템 프롬프트 ────────────────────────────────────
+
+SYSTEM_PROMPT = f"""\
 당신은 서울시 치안 뉴스를 분석하는 전문 분류 AI입니다.
 뉴스 제목과 설명을 읽고 아래 기준에 따라 정확하게 분류하세요.
 
-## 분류 기준
-
-**Level 1 (생활 불편)**
-쓰레기 무단투기, 노상방뇨, 고성방가, 층간소음, 청소년 비행 등
-실생활 불편을 유발하지만 직접적 신체 위협은 없는 사건
-
-**Level 2 (안전 불안)**
-취객 난동, 스토킹 전조, 자전거/택배 절도, 기물 파손, 음주운전 등
-재산 피해 또는 잠재적 위협이 있는 사건
-
-**Level 3 (신변 위협)**
-주거 침입, 강도, 살인, 성범죄(몰카 포함), 방화, 흉기 난동 등
-생명·신체에 직접 위협을 가하는 중대 범죄
-
-**기타**
-부동산 광고, 맛집 홍보, 행정 공지, 교통 정보, 스포츠 기사 등
-치안/범죄/사고와 무관한 콘텐츠
+{_CRITERIA}
 
 ## 응답 규칙
 - 반드시 JSON 형식으로만 응답하세요.
-- level 필드: 1, 2, 3 (정수) 또는 "기타" (문자열)
-- summary 필드: 기사 핵심 내용을 한국어 1~2 문장으로 요약 (기타는 null)
+- level: 1, 2, 3 (정수) 또는 "기타" (문자열)
+- category_tag: 해당 레벨의 중분류 이름 (기타는 null)
+- summary: 기사 핵심 내용을 한국어 1~2 문장으로 요약 (기타는 null)
 - 판단 근거가 불충분하면 가장 낮은 레벨로 분류하세요.
 
 응답 예시:
-{"level": 2, "summary": "서울 마포구에서 취객이 편의점 직원에게 행패를 부려 경찰에 인계됐다."}
-{"level": "기타", "summary": null}
+{{"level": 2, "category_tag": "재산 범죄", "summary": "서울 강남구에서 택배 도난 사건이 잇따라 발생했다."}}
+{{"level": "기타", "category_tag": null, "summary": null}}
+"""
+
+# ── 배치 시스템 프롬프트 ────────────────────────────────────
+
+BATCH_SYSTEM_PROMPT = f"""\
+당신은 서울시 치안 뉴스를 분석하는 전문 분류 AI입니다.
+번호가 매겨진 뉴스 목록을 읽고, 아래 기준에 따라 각각을 정확하게 분류하세요.
+
+{_CRITERIA}
+
+## 응답 규칙
+- 반드시 JSON 형식으로만 응답하세요.
+- {{"results": [{{"id": <번호>, "level": <레벨>, "category_tag": <중분류>, "summary": <요약>}}, ...]}} 형식으로 응답하세요.
+- level: 1, 2, 3 (정수) 또는 "기타" (문자열)
+- category_tag: 해당 레벨의 중분류 이름 (기타는 null)
+  - Level 1 허용값: "기초질서 위반", "인근 소란", "유해 환경"
+  - Level 2 허용값: "대인 불안", "재산 범죄", "질서 위반", "시설 위반"
+  - Level 3 허용값: "침입 범죄", "대인 강력", "성범죄", "사회 재난"
+- summary: 기사 핵심 내용을 한국어 1~2 문장으로 요약 (기타는 null)
+- 판단 근거가 불충분하면 가장 낮은 레벨로 분류하세요.
+- 입력된 모든 기사 번호에 대한 결과를 빠짐없이 포함하세요.
 """
 
 
+def _validate_tag(level: int, tag: str | None) -> str | None:
+    """레벨에 맞지 않는 태그는 가장 가까운 유효 태그로 교정한다."""
+    if tag is None:
+        return None
+    if tag in _VALID_TAGS.get(level, set()):
+        return tag
+    recommended = _TAG_RECOMMEND.get((level, tag))
+    if recommended:
+        logger.info("레벨 %d 태그 교정: '%s' → '%s'", level, tag, recommended)
+        return recommended
+    logger.warning("레벨 %d에 맞지 않는 태그 '%s', null 처리", level, tag)
+    return None
+
+
 class ClaudeClassifier:
-    """OpenAI API를 사용해 뉴스를 치안 레벨로 분류한다."""
+    """OpenAI API를 사용해 뉴스를 치안 레벨 + 중분류로 분류한다."""
 
     def __init__(self) -> None:
         if not OPENAI_API_KEY:
-            raise EnvironmentError(
-                "OPENAI_API_KEY 환경변수가 설정되지 않았습니다."
-            )
+            raise EnvironmentError("OPENAI_API_KEY 환경변수가 설정되지 않았습니다.")
         self._client = OpenAI(api_key=OPENAI_API_KEY)
 
     def classify(self, title: str, description: str, region: str) -> dict:
         """
         단건 뉴스를 분류한다.
 
-        Args:
-            title: 뉴스 제목
-            description: 뉴스 설명 (네이버 API snippet)
-            region: 검색에 사용된 지역구 이름
-
         Returns:
-            {
-                "level": int | "기타",
-                "summary": str | None,
-            }
+            {"level": int|"기타", "category_tag": str|None, "summary": str|None}
         """
         user_message = (
             f"지역: {region}\n"
@@ -86,7 +221,7 @@ class ClaudeClassifier:
         try:
             response = self._client.chat.completions.create(
                 model=OPENAI_MODEL,
-                max_tokens=256,
+                max_tokens=300,
                 response_format={"type": "json_object"},
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},
@@ -94,36 +229,126 @@ class ClaudeClassifier:
                 ],
             )
             raw = response.choices[0].message.content.strip()
-
             result = json.loads(raw)
+
             level = result.get("level")
+            tag   = result.get("category_tag")
             summary = result.get("summary")
 
-            if level not in (1, 2, 3, "기타"):
-                logger.warning("알 수 없는 레벨값 '%s', 기타로 처리", level)
-                level = "기타"
-                summary = None
+            # 문자열 숫자 → int 정규화
+            if isinstance(level, str) and level.isdigit():
+                level = int(level)
 
-            return {"level": level, "summary": summary}
+            if level not in _VALID_LEVELS:
+                logger.warning("알 수 없는 레벨값 '%s', 기타로 처리", level)
+                return {"level": "기타", "category_tag": None, "summary": None}
+
+            if level != "기타":
+                tag = _validate_tag(level, tag)
+
+            return {"level": level, "category_tag": tag, "summary": summary}
 
         except json.JSONDecodeError:
             logger.warning("JSON 파싱 실패, 기타로 처리. 원본: %s", raw[:100])
-            return {"level": "기타", "summary": None}
+            return {"level": "기타", "category_tag": None, "summary": None}
         except Exception as e:
             logger.error("분류 오류: %s", e)
-            return {"level": "기타", "summary": None}
+            return {"level": "기타", "category_tag": None, "summary": None}
 
     def classify_batch(self, articles: list[dict]) -> list[dict]:
         """
-        여러 기사를 순차적으로 분류한다.
-        각 기사 dict에 'level', 'summary' 필드를 추가하여 반환.
-
-        Args:
-            articles: naver_collector에서 반환된 raw article dict 목록
+        여러 기사를 한 번의 API 호출로 분류한다 (진짜 배치 처리).
+        실패 시 개별 분류로 폴백.
 
         Returns:
-            분류 결과가 추가된 article dict 목록 (기타 제외)
+            category_level, category_tag, summary 필드가 추가된 article dict 목록 (기타 제외)
         """
+        if not articles:
+            return []
+
+        parts = []
+        for i, article in enumerate(articles, 1):
+            parts.append(
+                f"[{i}]\n"
+                f"지역: {article['region_name']}\n"
+                f"제목: {article['title']}\n"
+                f"내용: {article.get('description', '(내용 없음)')}"
+            )
+        user_message = "\n\n".join(parts)
+
+        raw = ""
+        for attempt in range(_RATE_LIMIT_RETRIES + 1):
+            try:
+                response = self._client.chat.completions.create(
+                    model=OPENAI_MODEL,
+                    max_tokens=min(200 * len(articles), 4096),
+                    response_format={"type": "json_object"},
+                    messages=[
+                        {"role": "system", "content": BATCH_SYSTEM_PROMPT},
+                        {"role": "user", "content": user_message},
+                    ],
+                )
+                raw = response.choices[0].message.content.strip()
+                data = json.loads(raw)
+
+                # results 키가 없거나 최상위 배열로 반환되는 경우 대응
+                results_list = data.get("results") or data.get("items") or (data if isinstance(data, list) else [])
+                if not results_list:
+                    logger.warning("배치 응답에 results 없음, 원본: %s", raw[:200])
+                    return self._classify_individually(articles)
+
+                # id가 int 또는 str로 올 수 있으므로 int로 정규화
+                result_map = {int(r["id"]): r for r in results_list if "id" in r}
+
+                classified = []
+                for i, article in enumerate(articles, 1):
+                    r = result_map.get(i, {})
+                    level   = r.get("level")
+                    tag     = r.get("category_tag")
+                    summary = r.get("summary")
+
+                    # 문자열 숫자 → int 정규화 ('2' → 2)
+                    if isinstance(level, str) and level.isdigit():
+                        level = int(level)
+
+                    if level not in _VALID_LEVELS:
+                        logger.warning("배치 [%d] 알 수 없는 레벨값 '%s', 기타로 처리", i, level)
+                        continue
+
+                    if level == "기타":
+                        logger.debug("기타 분류, 저장 제외: %s", article["title"][:50])
+                        continue
+
+                    article["category_level"] = level
+                    article["category_tag"]   = _validate_tag(level, tag)
+                    article["summary"]        = summary
+                    classified.append(article)
+
+                return classified
+
+            except RateLimitError as e:
+                if attempt < _RATE_LIMIT_RETRIES:
+                    wait = _RATE_LIMIT_BACKOFF[attempt]
+                    logger.warning(
+                        "Rate limit 초과 (시도 %d/%d), %d초 대기 후 재시도...",
+                        attempt + 1, _RATE_LIMIT_RETRIES, wait,
+                    )
+                    time.sleep(wait)
+                else:
+                    logger.error("Rate limit 재시도 횟수 초과, 배치 건너뜀: %s", e)
+                    return []
+
+            except json.JSONDecodeError:
+                logger.warning("배치 JSON 파싱 실패, 개별 분류로 폴백. 원본: %s", raw[:200])
+                return self._classify_individually(articles)
+            except Exception as e:
+                logger.error("배치 분류 오류, 개별 분류로 폴백: %s", e)
+                return self._classify_individually(articles)
+
+        return []
+
+    def _classify_individually(self, articles: list[dict]) -> list[dict]:
+        """배치 실패 시 개별 분류로 폴백."""
         classified = []
         for article in articles:
             result = self.classify(
@@ -132,11 +357,9 @@ class ClaudeClassifier:
                 region=article["region_name"],
             )
             if result["level"] == "기타":
-                logger.debug("기타 분류, 저장 제외: %s", article["title"][:50])
                 continue
-
             article["category_level"] = result["level"]
-            article["summary"] = result["summary"]
+            article["category_tag"]   = result["category_tag"]
+            article["summary"]        = result["summary"]
             classified.append(article)
-
         return classified

--- a/news-collector/config.py
+++ b/news-collector/config.py
@@ -5,19 +5,20 @@ Ziply 치안 뉴스 수집기 - 설정 및 상수 정의
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv()  # news-collector/.env 없으면 자동으로 상위 폴더 탐색
 
 # ── 외부 API ─────────────────────────────────────────────
 NAVER_CLIENT_ID = os.getenv("NAVER_CLIENT_ID")
 NAVER_CLIENT_SECRET = os.getenv("NAVER_CLIENT_SECRET")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
-# ── MySQL (ziply-mysql Docker 컨테이너) ───────────────────
+# ── MySQL ─────────────────────────────────────────────────
+# DB_PASSWORD 없으면 루트 .env의 MYSQL_ROOT_PASSWORD 사용
 DB_HOST = os.getenv("DB_HOST", "127.0.0.1")
 DB_PORT = int(os.getenv("DB_PORT", "3306"))
 DB_USER = os.getenv("DB_USER", "root")
-DB_PASSWORD = os.getenv("DB_PASSWORD", "ziply_master_pw")
-DB_NAME = os.getenv("DB_NAME", "ziply_main")
+DB_PASSWORD = os.getenv("DB_PASSWORD") or os.getenv("MYSQL_ROOT_PASSWORD", "ziply_master_pw")
+DB_NAME = os.getenv("DB_NAME", "ziply_analysis")
 
 DATABASE_URL = (
     f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"

--- a/news-collector/db_handler.py
+++ b/news-collector/db_handler.py
@@ -60,6 +60,7 @@ class SafetyNews(Base):
     title_hash    = Column(String(32), unique=True, nullable=True)  # L2 중복 방지
     published_at  = Column(DateTime, nullable=False)
     category_level = Column(SmallInteger, nullable=False)    # 1, 2, 3
+    category_tag  = Column(String(30), nullable=True)        # 중분류 (예: '재산 범죄', '대인 강력')
     region_name   = Column(String(50), nullable=True)        # '동작구', '상도동' 등
     summary       = Column(Text, nullable=True)              # LLM 요약
     created_at    = Column(DateTime, default=datetime.utcnow)
@@ -141,25 +142,28 @@ def upsert_news(session: Session, news_item: dict) -> Optional[SafetyNews]:
     """
     단건 뉴스를 DB에 저장한다.
     content_url 또는 title_hash 가 이미 존재하면 건너뛴다(L1+L2 중복 방지).
+    savepoint를 사용해 중복 시 해당 건만 롤백, 세션 전체는 유지한다.
     """
     title_hash = make_title_hash(news_item["title"])
 
+    raw_url = news_item.get("content_url")
     record = SafetyNews(
         title=news_item["title"][:255],
-        content_url=news_item.get("content_url"),
+        content_url=raw_url[:500] if raw_url else None,
         title_hash=title_hash,
         published_at=news_item["published_at"],
         category_level=news_item["category_level"],
+        category_tag=news_item.get("category_tag"),
         region_name=news_item.get("region_name"),
         summary=news_item.get("summary"),
     )
     try:
-        session.add(record)
-        session.flush()
+        with session.begin_nested():   # savepoint — 실패 시 이 건만 롤백
+            session.add(record)
+            session.flush()
         logger.debug("저장: %s", record.title[:50])
         return record
     except IntegrityError:
-        session.rollback()
         logger.debug(
             "중복 건너뜀 (URL 또는 제목 해시): %s",
             news_item.get("content_url", news_item["title"][:40]),

--- a/news-collector/fix_null_tags.py
+++ b/news-collector/fix_null_tags.py
@@ -1,0 +1,122 @@
+"""
+category_tag가 null인 기존 레코드를 재분류해서 MySQL + Qdrant 업데이트.
+
+사용법:
+    python fix_null_tags.py             # 전체 null 레코드 처리
+    python fix_null_tags.py --dry-run   # 업데이트 없이 건수만 확인
+"""
+
+import argparse
+import logging
+import sys
+
+from sqlalchemy import select, update
+
+from claude_classifier import ClaudeClassifier
+from db_handler import SafetyNews, create_db_engine, get_session_factory
+from qdrant_handler import QdrantNewsHandler
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 20
+
+
+def fix_null_tags(dry_run: bool = False) -> None:
+    engine = create_db_engine()
+    SessionFactory = get_session_factory(engine)
+
+    with SessionFactory() as session:
+        rows = session.execute(
+            select(SafetyNews).where(
+                SafetyNews.category_tag.is_(None),
+                SafetyNews.category_level.in_([1, 2, 3]),
+            )
+        ).scalars().all()
+
+    total = len(rows)
+    logger.info("category_tag null 레코드: %d건", total)
+
+    if total == 0:
+        logger.info("수정할 레코드 없음.")
+        return
+
+    if dry_run:
+        logger.info("[DRY-RUN] 업데이트 건너뜀.")
+        return
+
+    classifier = ClaudeClassifier()
+
+    try:
+        qdrant = QdrantNewsHandler()
+        qdrant_enabled = True
+    except Exception as e:
+        logger.warning("Qdrant 연결 실패, Qdrant 업데이트 건너뜀: %s", e)
+        qdrant_enabled = False
+
+    updated = 0
+    batches = [rows[i: i + BATCH_SIZE] for i in range(0, len(rows), BATCH_SIZE)]
+
+    for batch_idx, batch in enumerate(batches, 1):
+        articles = [
+            {
+                "title":       row.title,
+                "description": row.summary or "",
+                "region_name": row.region_name or "",
+            }
+            for row in batch
+        ]
+
+        results = classifier.classify_batch(articles)
+        # classify_batch는 기타를 제외하고 반환하므로 id 매핑이 필요
+        # 여기서는 단건 분류로 확실하게 처리
+        for row in batch:
+            result = classifier.classify(
+                title=row.title,
+                description=row.summary or "",
+                region=row.region_name or "",
+            )
+            tag = result.get("category_tag")
+            if not tag:
+                logger.debug("재분류 후에도 tag 없음: id=%d", row.id)
+                continue
+
+            with SessionFactory() as session:
+                session.execute(
+                    update(SafetyNews)
+                    .where(SafetyNews.id == row.id)
+                    .values(category_tag=tag)
+                )
+                session.commit()
+
+            if qdrant_enabled:
+                qdrant.upsert(
+                    news_item={
+                        "title":          row.title,
+                        "content_url":    row.content_url or "",
+                        "published_at":   row.published_at,
+                        "category_level": row.category_level,
+                        "category_tag":   tag,
+                        "region_name":    row.region_name or "",
+                        "summary":        row.summary or "",
+                    },
+                    mysql_id=row.id,
+                )
+
+            updated += 1
+
+        logger.info("배치 %d/%d 완료 (누적 업데이트: %d건)", batch_idx, len(batches), updated)
+
+    logger.info("완료: %d건 업데이트 / 전체 null %d건", updated, total)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="category_tag null 레코드 재분류 업데이트")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    fix_null_tags(dry_run=args.dry_run)

--- a/news-collector/main.py
+++ b/news-collector/main.py
@@ -11,7 +11,7 @@ Ziply 치안 뉴스 수집기 - 메인 파이프라인 실행 스크립트
 import argparse
 import logging
 import sys
-import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 
 from claude_classifier import ClaudeClassifier
@@ -38,7 +38,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = 10
+# 한 번의 OpenAI 호출에 넣을 기사 수 (프롬프트 토큰 한도 고려)
+BATCH_SIZE = 20
+# 동시에 실행할 OpenAI 배치 호출 수 (rate limit 여유분 확보)
+MAX_CONCURRENT_BATCHES = 5
 
 
 def _process_district(
@@ -58,11 +61,14 @@ def _process_district(
 
     articles = deduplicate_by_title(articles)
 
+    batches = [articles[i : i + BATCH_SIZE] for i in range(0, len(articles), BATCH_SIZE)]
+    logger.info("%s 분류 시작: %d건 → %d배치 (동시 %d)", district, len(articles), len(batches), MAX_CONCURRENT_BATCHES)
+
     classified: list[dict] = []
-    for i in range(0, len(articles), BATCH_SIZE):
-        batch = articles[i : i + BATCH_SIZE]
-        classified.extend(classifier.classify_batch(batch))
-        time.sleep(0.3)
+    with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_BATCHES) as pool:
+        futures = {pool.submit(classifier.classify_batch, batch): idx for idx, batch in enumerate(batches)}
+        for future in as_completed(futures):
+            classified.extend(future.result())
 
     excluded = len(articles) - len(classified)
     logger.info(
@@ -109,6 +115,7 @@ def _bulk_upsert_with_ids(session, news_list: list[dict]) -> list[dict]:
 
 def run_pipeline(
     districts: list[str] | None = None,
+    from_district: str | None = None,
     dry_run: bool = False,
 ) -> None:
     """
@@ -116,10 +123,21 @@ def run_pipeline(
 
     Args:
         districts: 수집할 구 목록 (None이면 25개 전체)
+        from_district: 이 구부터 이어서 수집 (앞 구는 건너뜀)
         dry_run: True면 DB 저장 생략
     """
     start_time = datetime.now()
     target = districts or SEOUL_DISTRICTS
+
+    if from_district:
+        if from_district not in target:
+            logger.error("알 수 없는 구 이름: %s", from_district)
+            sys.exit(1)
+        skip_idx = target.index(from_district)
+        skipped = target[:skip_idx]
+        target = target[skip_idx:]
+        if skipped:
+            logger.info("건너뜀 (이미 수집됨): %s", ", ".join(skipped))
     logger.info("=== Ziply 치안 뉴스 수집 시작 (%s) ===", start_time.strftime("%Y-%m-%d %H:%M"))
     logger.info("대상 구: %d개 | dry-run: %s", len(target), dry_run)
 
@@ -176,6 +194,13 @@ def main() -> None:
         help="특정 구만 수집 (예: 동작구). 생략 시 25개 전체 수집.",
     )
     parser.add_argument(
+        "--from-district",
+        type=str,
+        default=None,
+        dest="from_district",
+        help="이 구부터 이어서 수집 (예: 마포구). 앞 구는 건너뜀.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         default=False,
@@ -191,7 +216,7 @@ def main() -> None:
             sys.exit(1)
         districts = [args.district]
 
-    run_pipeline(districts=districts, dry_run=args.dry_run)
+    run_pipeline(districts=districts, from_district=args.from_district, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/news-collector/qdrant_handler.py
+++ b/news-collector/qdrant_handler.py
@@ -133,10 +133,13 @@ class QdrantNewsHandler:
             logger.warning("Qdrant upsert 실패 id=%d: %s", mysql_id, e)
             return False
 
+    # OpenAI Embeddings API 및 Qdrant 단일 요청 한도
+    _EMBED_CHUNK = 500
+
     def bulk_upsert(self, news_items: list[dict], mysql_ids: list[int]) -> int:
         """
-        여러 뉴스를 배치로 Qdrant에 저장한다.
-        OpenAI Embeddings API는 배치 요청을 지원하므로 한 번에 임베딩.
+        여러 뉴스를 청크 단위로 나눠 Qdrant에 저장한다.
+        OpenAI Embeddings API / Qdrant 요청 한도(_EMBED_CHUNK)를 초과하지 않도록 분할.
 
         Returns:
             성공한 건수
@@ -144,9 +147,18 @@ class QdrantNewsHandler:
         if not news_items:
             return 0
 
+        total = 0
+        for i in range(0, len(news_items), self._EMBED_CHUNK):
+            chunk_items = news_items[i : i + self._EMBED_CHUNK]
+            chunk_ids   = mysql_ids[i : i + self._EMBED_CHUNK]
+            total += self._upsert_chunk(chunk_items, chunk_ids)
+
+        logger.info("Qdrant 배치 upsert 완료: %d건", total)
+        return total
+
+    def _upsert_chunk(self, news_items: list[dict], mysql_ids: list[int]) -> int:
         try:
             texts = [self._build_embed_text(item) for item in news_items]
-
             response = self._openai.embeddings.create(
                 model=EMBEDDING_MODEL,
                 input=[t[:8000] for t in texts],
@@ -170,17 +182,17 @@ class QdrantNewsHandler:
                         "content_url": item.get("content_url", ""),
                         "published_at": published_str,
                         "category_level": item.get("category_level"),
+                        "category_tag": item.get("category_tag"),
                         "region_name": item.get("region_name", ""),
                         "summary": item.get("summary", ""),
                     },
                 ))
 
             self._qdrant.upsert(collection_name=COLLECTION_NAME, points=points)
-            logger.info("Qdrant 배치 upsert 완료: %d건", len(points))
             return len(points)
 
         except Exception as e:
-            logger.error("Qdrant 배치 upsert 실패: %s", e)
+            logger.error("Qdrant 청크 upsert 실패: %s", e)
             return 0
 
     def search(self, query: str, region_name: Optional[str] = None,

--- a/news-collector/sync_qdrant.py
+++ b/news-collector/sync_qdrant.py
@@ -1,0 +1,72 @@
+"""
+MySQL에 저장된 특정 구 뉴스를 Qdrant에 재동기화하는 스크립트.
+
+사용법:
+    python sync_qdrant.py --district 강북구
+    python sync_qdrant.py --district 강북구 --dry-run
+"""
+
+import argparse
+import logging
+import sys
+
+from sqlalchemy import select
+
+from config import DATABASE_URL
+from db_handler import SafetyNews, create_db_engine, get_session_factory
+from qdrant_handler import QdrantNewsHandler
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger(__name__)
+
+
+def sync_district(district: str, dry_run: bool = False) -> None:
+    engine = create_db_engine()
+    SessionFactory = get_session_factory(engine)
+
+    with SessionFactory() as session:
+        rows = session.execute(
+            select(SafetyNews).where(SafetyNews.region_name.like(f"%{district[:2]}%"))
+        ).scalars().all()
+
+    logger.info("MySQL에서 %s 관련 %d건 조회됨", district, len(rows))
+
+    if not rows:
+        logger.warning("조회된 데이터 없음. 구 이름 확인: %s", district)
+        return
+
+    if dry_run:
+        logger.info("[DRY-RUN] Qdrant upsert 건너뜀")
+        return
+
+    qdrant = QdrantNewsHandler()
+
+    news_items = []
+    mysql_ids = []
+    for row in rows:
+        news_items.append({
+            "title":          row.title,
+            "content_url":    row.content_url or "",
+            "published_at":   row.published_at,
+            "category_level": row.category_level,
+            "category_tag":   row.category_tag,
+            "region_name":    row.region_name,
+            "summary":        row.summary or "",
+        })
+        mysql_ids.append(row.id)
+
+    saved = qdrant.bulk_upsert(news_items, mysql_ids)
+    logger.info("Qdrant 동기화 완료: %d건 / 전체 %d건", saved, len(rows))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MySQL → Qdrant 재동기화")
+    parser.add_argument("--district", required=True, help="동기화할 구 이름 (예: 강북구)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    sync_district(args.district, dry_run=args.dry_run)


### PR DESCRIPTION
- SafetyNews 도메인에 category_tag(중분류) 필드 추가
- 치안 뉴스 조회 API에 page/size 파라미터로 페이지네이션 지원
- SafetyNewsResponse에 page, totalPages 등 페이지 메타 정보 포함
- categoryLevel을 숫자 대신 레벨명 문자열로 반환하도록 변경
- publishedAt을 LocalDate 형태로 응답하도록 변경
- news-collector: claude_classifier 개선, qdrant 동기화 스크립트 추가