### PR TITLE
feat: 치안 뉴스 API 레벨별 조회 분리

### DIFF
--- a/analysis/src/main/java/ziply/analysis/controller/RouteAnalysisController.java
+++ b/analysis/src/main/java/ziply/analysis/controller/RouteAnalysisController.java
@@ -53,6 +53,7 @@ public class RouteAnalysisController {
      * 탐색카드 내 각 집의 동(법정동) 기반 치안 뉴스 집계 조회.
      *
      * @param period 조회 기간 (개월): 3, 6, 12 (기본값 3)
+     * @param level  뉴스 레벨: 1(생활 불편), 2(안전 불안), 3(신변 위협) (기본값 3)
      * @param page   페이지 번호 (0-based, 기본값 0)
      * @param size   페이지당 항목 수 (기본값 10, 최대 50)
      */
@@ -61,21 +62,22 @@ public class RouteAnalysisController {
             @PathVariable UUID searchCardId,
             @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "3") int period,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        if (!isValidPeriod(period) || !isValidSize(size)) {
+            @RequestParam(defaultValue = "3") int level,
+            @RequestParam(defaultValue = "0") int page) {
+        if (!isValidPeriod(period) || !isValidLevel(level)) {
             return ResponseEntity.badRequest().build();
         }
-        return ResponseEntity.ok(safetyNewsService.getNewsAnalysis(searchCardId, userId, period, page, size));
+        return ResponseEntity.ok(safetyNewsService.getNewsAnalysis(searchCardId, userId, period, level, page, 10));
     }
 
     private boolean isValidPeriod(int period) {
         return period == 3 || period == 6 || period == 12;
     }
 
-    private boolean isValidSize(int size) {
-        return size >= 1 && size <= 50;
+    private boolean isValidLevel(int level) {
+        return level >= 1 && level <= 3;
     }
+
 
     /**
      * 자연어 쿼리로 치안 뉴스 시맨틱 검색 (Qdrant).

--- a/analysis/src/main/java/ziply/analysis/controller/RouteAnalysisController.java
+++ b/analysis/src/main/java/ziply/analysis/controller/RouteAnalysisController.java
@@ -63,13 +63,18 @@ public class RouteAnalysisController {
             @RequestParam(defaultValue = "3") int period,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        if (period != 3 && period != 6 && period != 12) {
-            return ResponseEntity.badRequest().build();
-        }
-        if (size < 1 || size > 50) {
+        if (!isValidPeriod(period) || !isValidSize(size)) {
             return ResponseEntity.badRequest().build();
         }
         return ResponseEntity.ok(safetyNewsService.getNewsAnalysis(searchCardId, userId, period, page, size));
+    }
+
+    private boolean isValidPeriod(int period) {
+        return period == 3 || period == 6 || period == 12;
+    }
+
+    private boolean isValidSize(int size) {
+        return size >= 1 && size <= 50;
     }
 
     /**

--- a/analysis/src/main/java/ziply/analysis/dto/response/SafetyNewsResponse.java
+++ b/analysis/src/main/java/ziply/analysis/dto/response/SafetyNewsResponse.java
@@ -8,8 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * GET /api/v1/analysis/news/{searchCardId}?period=3&page=0&size=10 응답 DTO.
- * 탐색카드 내 각 집(houseId)의 동별 치안 뉴스 집계 결과 (페이지네이션 포함).
+ * GET /api/v1/analysis/news/{searchCardId}?period=3&level=2&page=0&size=10 응답 DTO.
+ * level 파라미터로 레벨별 뉴스를 독립적으로 조회.
+ * level 생략 시 카운트/메시지만 반환 (탭 배지용).
  */
 @Getter
 @Builder
@@ -26,12 +27,12 @@ public class SafetyNewsResponse {
 
     private String message;         // 요약 메시지
 
-    private List<NewsItem> recentNews;   // 페이지네이션된 기사 목록
+    private List<NewsItem> news;    // 요청한 레벨의 기사 목록
 
     private int page;               // 현재 페이지 (0-based)
     private int size;               // 페이지당 항목 수
-    private long totalCount;        // 전체 기사 수
-    private int totalPages;         // 전체 페이지 수
+    private long totalCount;        // 해당 레벨 전체 기사 수
+    private int totalPages;         // 해당 레벨 전체 페이지 수
 
     @Getter
     @Builder
@@ -40,7 +41,7 @@ public class SafetyNewsResponse {
     public static class NewsItem {
         private String title;
         private String categoryLevel;   // "생활 불편 / 무질서" | "안전 불안 / 재산 위협" | "신변 위협 / 강력 범죄"
-        private String categoryTag;     // 중분류 (예: "재산 범죄", "대인 강력") — 재분류 전 null
+        private String categoryTag;     // 중분류 (예: "재산 범죄", "대인 강력")
         private LocalDate publishedAt;
         private String contentUrl;
         private String summary;

--- a/analysis/src/main/java/ziply/analysis/repository/SafetyNewsRepository.java
+++ b/analysis/src/main/java/ziply/analysis/repository/SafetyNewsRepository.java
@@ -43,4 +43,17 @@ public interface SafetyNewsRepository extends JpaRepository<SafetyNews, Long> {
     List<Object[]> countByLevelAndRegion(
             @Param("regionName") String regionName,
             @Param("since") LocalDateTime since);
+
+    /**
+     * 레벨 필터링 + 페이지네이션 조회.
+     */
+    @Query("SELECT s FROM SafetyNews s " +
+           "WHERE s.regionName LIKE %:regionName% " +
+           "AND s.publishedAt >= :since " +
+           "AND s.categoryLevel = :level")
+    Page<SafetyNews> findByRegionAndPeriodAndLevel(
+            @Param("regionName") String regionName,
+            @Param("since") LocalDateTime since,
+            @Param("level") int level,
+            Pageable pageable);
 }

--- a/analysis/src/main/java/ziply/analysis/service/AnalysisConsumer.java
+++ b/analysis/src/main/java/ziply/analysis/service/AnalysisConsumer.java
@@ -26,10 +26,10 @@ public class AnalysisConsumer {
     public void handleHouseCreatedEvent(String message) {
         try {
             HouseCreatedEvent event = objectMapper.readValue(message, HouseCreatedEvent.class);
-            log.info("[Analyst] 생성 이벤트 수신 성공: {}", event);
+            log.info("집 생성 이벤트 수신: {}", event);
             routeAnalysisService.processHouseCreation(event);
         } catch (Exception e) {
-            log.error("[Analyst] 생성 메시지 파싱 에러: {}", e.getMessage());
+            log.error("집 생성 메시지 처리 실패: {}", e.getMessage(), e);
         }
     }
 
@@ -37,10 +37,10 @@ public class AnalysisConsumer {
     public void handleHouseUpdatedEvent(String message) {
         try {
             HouseUpdatedEvent event = objectMapper.readValue(message, HouseUpdatedEvent.class);
-            log.info("[Analyst] 수정 이벤트 수신 성공: {}", event);
+            log.info("집 수정 이벤트 수신: {}", event);
             routeAnalysisService.processHouseUpdate(event);
         } catch (Exception e) {
-            log.error("[Analyst] 수정 메시지 파싱 에러: {}", e.getMessage());
+            log.error("집 수정 메시지 처리 실패: {}", e.getMessage(), e);
         }
     }
 
@@ -48,15 +48,13 @@ public class AnalysisConsumer {
     @KafkaListener(topics = "house-deleted", groupId = "analysis-group")
     public void handleHouseDeleted(String houseIdStr) {
         String cleanId = houseIdStr.replace("\"", "");
-
         try {
             Long houseId = Long.parseLong(cleanId);
-            log.info("[Analyst] 삭제 이벤트 수신 성공 - HouseId: {}", houseId);
-
+            log.info("집 삭제 이벤트 수신: houseId={}", houseId);
             houseRouteAnalysisRepository.deleteByHouseId(houseId);
-            log.info("[Analyst] 분석 데이터 삭제 완료 - HouseId: {}", houseId);
+            log.info("집 분석 데이터 삭제 완료: houseId={}", houseId);
         } catch (NumberFormatException e) {
-            log.error("[Analyst] 숫자 변환 실패. 원본 데이터: {}, 정제된 데이터: {}", houseIdStr, cleanId);
+            log.error("집 삭제 이벤트 houseId 파싱 실패: raw={}, clean={}", houseIdStr, cleanId, e);
         }
     }
 
@@ -64,16 +62,13 @@ public class AnalysisConsumer {
     @KafkaListener(topics = "search-card-deleted", groupId = "analysis-group")
     public void handleCardDeleted(String cardIdStr) {
         String cleanId = cardIdStr.replace("\"", "");
-
         try {
             UUID searchCardId = UUID.fromString(cleanId);
-            log.info("[Analyst] 카드 삭제 이벤트 수신 - CardId: {}", searchCardId);
-
+            log.info("탐색카드 삭제 이벤트 수신: searchCardId={}", searchCardId);
             houseRouteAnalysisRepository.deleteBySearchCardId(searchCardId);
-
-            log.info("[Analyst] 해당 카드의 모든 분석 데이터 삭제 완료 - CardId: {}", searchCardId);
+            log.info("탐색카드 분석 데이터 삭제 완료: searchCardId={}", searchCardId);
         } catch (Exception e) {
-            log.error("[Analyst] 카드 ID 변환 실패: {}", cleanId);
+            log.error("탐색카드 삭제 이벤트 ID 파싱 실패: raw={}", cleanId, e);
         }
     }
 
@@ -82,14 +77,11 @@ public class AnalysisConsumer {
     public void handleDemoDataReset(String message) {
         try {
             DemoDataResetEvent event = objectMapper.readValue(message, DemoDataResetEvent.class);
-            log.info("[DEMO-Analysis] 데모 초기화 이벤트 수신 - userId: {}, houseIds: {}", 
-                    event.getUserId(), event.getHouseIds());
-            
+            log.info("데모 초기화 이벤트 수신: userId={}, houseIds={}", event.getUserId(), event.getHouseIds());
             demoAnalysisService.resetDemoAnalysisData(event.getHouseIds());
-            
-            log.info("[DEMO-Analysis] 데모 초기화 처리 완료 - userId: {}", event.getUserId());
+            log.info("데모 초기화 완료: userId={}", event.getUserId());
         } catch (Exception e) {
-            log.error("[DEMO-Analysis] 데모 초기화 처리 실패: {}", e.getMessage(), e);
+            log.error("데모 초기화 처리 실패: {}", e.getMessage(), e);
         }
     }
 }

--- a/analysis/src/main/java/ziply/analysis/service/AnalysisConsumer.java
+++ b/analysis/src/main/java/ziply/analysis/service/AnalysisConsumer.java
@@ -1,7 +1,6 @@
 package ziply.analysis.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +20,7 @@ public class AnalysisConsumer {
     private final HouseRouteAnalysisRepository houseRouteAnalysisRepository;
     private final RouteAnalysisService routeAnalysisService;
     private final DemoAnalysisService demoAnalysisService;
-    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "house-created", groupId = "analysis-group")
     public void handleHouseCreatedEvent(String message) {

--- a/analysis/src/main/java/ziply/analysis/service/CardOwnershipValidator.java
+++ b/analysis/src/main/java/ziply/analysis/service/CardOwnershipValidator.java
@@ -1,0 +1,33 @@
+package ziply.analysis.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class CardOwnershipValidator {
+
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${services.review.url:http://review-service:8080}")
+    private String reviewServiceUrl;
+
+    public void validate(UUID searchCardId, Long userId) {
+        webClientBuilder.build().get()
+                .uri(reviewServiceUrl + "/api/v1/review/card/{searchCardId}/owner-check?userId={userId}",
+                        searchCardId, userId)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, cr -> Mono.error(new AccessDeniedException("권한 확인 실패")))
+                .bodyToMono(Boolean.class)
+                .map(isOwner -> {
+                    if (!isOwner) throw new AccessDeniedException("접근 권한이 없습니다.");
+                    return isOwner;
+                }).block();
+    }
+}

--- a/analysis/src/main/java/ziply/analysis/service/KakaoRouteProvider.java
+++ b/analysis/src/main/java/ziply/analysis/service/KakaoRouteProvider.java
@@ -1,7 +1,6 @@
 package ziply.analysis.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -14,15 +13,18 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class KakaoRouteProvider {
 
     @Value("${kakao.api.key}")
     private String kakaoRestApiKey;
 
-    private final WebClient webClient = WebClient.create("https://apis-navi.kakaomobility.com");
+    private final WebClient webClient;
     private static final String DIRECTION_ENDPOINT = "/v1/directions";
+
+    public KakaoRouteProvider(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl("https://apis-navi.kakaomobility.com").build();
+    }
 
     public record RouteResult(int durationSeconds, int distanceMeters) {
     }
@@ -31,30 +33,32 @@ public class KakaoRouteProvider {
         String origin = String.format("%f,%f", startLon, startLat);
         String destination = String.format("%f,%f", endLon, endLat);
 
-        KakaoRouteResponse response;
         try {
-            response = webClient.get()
-                    .uri(uriBuilder -> uriBuilder.path(DIRECTION_ENDPOINT).queryParam("origin", origin)
-                            .queryParam("destination", destination).queryParam("priority", "RECOMMEND")
+            KakaoRouteResponse response = webClient.get()
+                    .uri(uriBuilder -> uriBuilder.path(DIRECTION_ENDPOINT)
+                            .queryParam("origin", origin)
+                            .queryParam("destination", destination)
+                            .queryParam("priority", "RECOMMEND")
                             .queryParam("profile", "walking").build())
-                    .header("Authorization", "KakaoAK " + kakaoRestApiKey).retrieve()
+                    .header("Authorization", "KakaoAK " + kakaoRestApiKey)
+                    .retrieve()
                     .bodyToMono(KakaoRouteResponse.class).block();
 
+            if (response == null || response.getRoutes() == null || response.getRoutes().isEmpty()) {
+                log.warn("카카오 도보 API: 경로를 찾을 수 없음. Origin={}, Dest={}", origin, destination);
+                return new RouteResult(0, 0);
+            }
+            return new RouteResult(0, response.getDistanceMeters());
+
         } catch (Exception e) {
-            log.error("카카오 경로 API 호출 실패: Origin={}, Dest={}", origin, destination, e);
-            throw new RuntimeException("카카오 API 호출 실패", e);
-        }
-        if (response == null || response.getRoutes() == null || response.getRoutes().isEmpty()) {
-            log.warn("카카오 API: 경로를 찾을 수 없음 (Empty Route). Origin={}, Dest={}", origin, destination);
+            log.error("카카오 도보 경로 API 호출 실패: Origin={}, Dest={}", origin, destination, e);
             return new RouteResult(0, 0);
         }
-        return new RouteResult(0, response.getDistanceMeters());
     }
 
     public RouteResult getCarRoute(double startLat, double startLon, double endLat, double endLon) {
         String origin = String.format("%f,%f", startLon, startLat);
         String destination = String.format("%f,%f", endLon, endLat);
-
         String departureTime = getNextWeekdayEightAM();
 
         try {
@@ -62,7 +66,7 @@ public class KakaoRouteProvider {
                     .uri(uriBuilder -> uriBuilder.path(DIRECTION_ENDPOINT)
                             .queryParam("origin", origin)
                             .queryParam("destination", destination)
-                            .queryParam("origin_time", departureTime) // 출근 시간 적용
+                            .queryParam("origin_time", departureTime)
                             .queryParam("priority", "RECOMMEND")
                             .build())
                     .header("Authorization", "KakaoAK " + kakaoRestApiKey)
@@ -78,11 +82,10 @@ public class KakaoRouteProvider {
             JsonNode summary = response.at("/routes/0/summary");
             int duration = summary.path("duration").asInt();
             int distance = summary.path("distance").asInt();
-
             return new RouteResult(duration, distance);
 
         } catch (Exception e) {
-            log.error("카카오 자동차 경로 API 호출 실패 (출근시간 모드): {}", e.getMessage());
+            log.error("카카오 자동차 경로 API 호출 실패: Origin={}, Dest={}", origin, destination, e);
             return new RouteResult(0, 0);
         }
     }

--- a/analysis/src/main/java/ziply/analysis/service/RouteAnalysisService.java
+++ b/analysis/src/main/java/ziply/analysis/service/RouteAnalysisService.java
@@ -5,13 +5,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 import ziply.analysis.domain.HouseAnalysis;
 import ziply.analysis.dto.response.*;
 import ziply.analysis.event.HouseCreatedEvent;
@@ -21,6 +16,7 @@ import ziply.analysis.repository.HouseRouteAnalysisRepository;
 import ziply.analysis.service.KakaoRouteProvider.RouteResult;
 import ziply.analysis.service.safety.SafetyScoringService;
 import ziply.analysis.service.safety.SafetyScoringService.SafetyAnalysisResult;
+import ziply.analysis.util.HouseLabelMapper;
 
 @Slf4j
 @Service
@@ -31,7 +27,6 @@ public class RouteAnalysisService {
     private static final double AVG_BIKE_SPEED_KM_H = 15.0;
     private static final int MINUTES_IN_HOUR = 60;
 
-    // --- [추가] 안내 메시지 상수 처리 ---
     private static final String CLIMATE_CARD_INFO = "서울지역 대중교통은 기후동행카드를 통해 62,000원(만19~39세 55,000원)으로 30일 무제한 이용가능하니 고려해보세요.";
     private static final String BIKE_RENTAL_INFO = "서울시 따릉이는 1일권(1일 1시간 기준 1,000원)과 30일 정기권(30일간 매일 1시간 이용, 5,000원)이 있어요.";
 
@@ -41,11 +36,9 @@ public class RouteAnalysisService {
     private final KakaoInfrastructureService kakaoInfrastructureService;
     private final NoiseScoringService noiseScoringService;
     private final SafetyScoringService safetyScoringService;
-    private final WebClient.Builder webClientBuilder;
     private final OdsayTransitProvider transitProvider;
-
-    @Value("${services.review.url:http://review-service:8080}")
-    private String reviewServiceUrl;
+    private final CardOwnershipValidator cardOwnershipValidator;
+    private final HouseLabelMapper houseLabelMapper;
 
     @Transactional
     public void processHouseCreation(HouseCreatedEvent event) {
@@ -101,7 +94,6 @@ public class RouteAnalysisService {
                 (distanceKm > 0) ? (int) Math.round((distanceKm / AVG_WALKING_SPEED_KM_H) * MINUTES_IN_HOUR) : 0;
         int bikeTimeMin = (distanceKm > 0) ? (int) Math.round((distanceKm / AVG_BIKE_SPEED_KM_H) * MINUTES_IN_HOUR) : 0;
 
-        // 대중교통 정보가 없으면 도보 추천 (시간 제한 없음)
         if (transit.timeMin() == 0 && "정보 없음".equals(transit.paymentStr()) && walkTimeMin > 0) {
             transit = new TransitResult(0, "도보가 더 빨라요", 0);
         }
@@ -124,13 +116,13 @@ public class RouteAnalysisService {
 
     @Transactional(readOnly = true)
     public List<BasePointAnalysisDto> getSearchCardDistanceAnalysis(UUID searchCardId, Long userId) {
-        checkCardOwner(searchCardId, userId);
+        cardOwnershipValidator.validate(searchCardId, userId);
         List<HouseAnalysis> allData = routeAnalysisRepository.findBySearchCardId(searchCardId);
         if (allData.isEmpty()) {
             return Collections.emptyList();
         }
 
-        Map<Long, String> houseLabelMap = createHouseLabelMap(allData);
+        Map<Long, String> houseLabelMap = houseLabelMapper.build(allData);
         Map<Long, List<HouseAnalysis>> grouped = allData.stream()
                 .collect(Collectors.groupingBy(HouseAnalysis::getBasePointId));
 
@@ -142,11 +134,9 @@ public class RouteAnalysisService {
     private BasePointAnalysisDto createBasePointAnalysis(
             List<HouseAnalysis> results,
             Map<Long, String> houseLabelMap) {
-        
-        // 도보 시간 기준 정렬
+
         results.sort(Comparator.comparing(HouseAnalysis::getWalkingTimeMin, Comparator.nullsLast(Integer::compareTo)));
 
-        // 도보 추천 집과 교통비 집 분류
         Map<Boolean, List<HouseAnalysis>> partitioned = results.stream()
                 .collect(Collectors.partitioningBy(
                     e -> "도보가 더 빨라요".equals(e.getTransitPaymentStr())
@@ -160,15 +150,12 @@ public class RouteAnalysisService {
                 .map(e -> formatFeeDetail(e, houseLabelMap.get(e.getHouseId())))
                 .toList();
 
-        // 메시지 생성
         String transportMessage = buildTransportMessage(feeDetails, walkingLabels);
-        
-        // 자전거 메시지: 모든 집이 도보 추천이면 불필요
-        String bikeMessage = (feeDetails.isEmpty() && !walkingLabels.isEmpty()) 
-            ? null 
+
+        String bikeMessage = (feeDetails.isEmpty() && !walkingLabels.isEmpty())
+            ? null
             : BIKE_RENTAL_INFO;
 
-        // DTO 변환
         List<HouseAnalysisDto> houseDtos = results.stream()
                 .map(e -> HouseAnalysisDto.from(e, houseLabelMap.get(e.getHouseId())))
                 .toList();
@@ -194,20 +181,17 @@ public class RouteAnalysisService {
     private String buildTransportMessage(List<String> feeDetails, List<String> walkingLabels) {
         StringBuilder sb = new StringBuilder();
 
-        // 교통비 정보
         if (!feeDetails.isEmpty()) {
             sb.append("한 달(30일) 기준 왕복 교통비는 ")
               .append(String.join(", ", feeDetails))
               .append("이에요. ");
         }
 
-        // 도보 추천
         if (!walkingLabels.isEmpty()) {
             sb.append(String.join(", ", walkingLabels))
               .append("는 도보로 이동 가능해요. ");
         }
 
-        // 기후동행카드 안내 (교통비 정보가 있을 때만)
         if (!feeDetails.isEmpty()) {
             sb.append(CLIMATE_CARD_INFO);
         }
@@ -217,13 +201,13 @@ public class RouteAnalysisService {
 
     @Transactional(readOnly = true)
     public List<LifeScoreAnalysisResponse> getLifeScoreAnalysis(UUID searchCardId, Long userId) {
-        checkCardOwner(searchCardId, userId);
+        cardOwnershipValidator.validate(searchCardId, userId);
         List<HouseAnalysis> allData = routeAnalysisRepository.findBySearchCardId(searchCardId);
         if (allData.isEmpty()) {
             return Collections.emptyList();
         }
 
-        Map<Long, String> labelMap = createHouseLabelMap(allData);
+        Map<Long, String> labelMap = houseLabelMapper.build(allData);
 
         return allData.stream()
                 .collect(Collectors.groupingBy(HouseAnalysis::getHouseId))
@@ -251,13 +235,13 @@ public class RouteAnalysisService {
 
     @Transactional(readOnly = true)
     public List<SafetyAnalysisResponse> getSafetyAnalysis(UUID searchCardId, Long userId) {
-        checkCardOwner(searchCardId, userId);
+        cardOwnershipValidator.validate(searchCardId, userId);
         List<HouseAnalysis> allData = routeAnalysisRepository.findBySearchCardId(searchCardId);
         if (allData.isEmpty()) {
             return Collections.emptyList();
         }
 
-        Map<Long, String> labelMap = createHouseLabelMap(allData);
+        Map<Long, String> labelMap = houseLabelMapper.build(allData);
 
         return allData.stream()
                 .collect(Collectors.groupingBy(HouseAnalysis::getHouseId))
@@ -279,29 +263,6 @@ public class RouteAnalysisService {
                 })
                 .sorted(Comparator.comparing(SafetyAnalysisResponse::getHouseId))
                 .toList();
-    }
-
-    private Map<Long, String> createHouseLabelMap(List<HouseAnalysis> allData) {
-        List<Long> distinctHouseIds = allData.stream().map(HouseAnalysis::getHouseId).distinct().sorted().toList();
-        Map<Long, String> labelMap = new HashMap<>();
-        for (int i = 0; i < distinctHouseIds.size(); i++) {
-            labelMap.put(distinctHouseIds.get(i), String.valueOf((char) ('A' + i)));
-        }
-        return labelMap;
-    }
-
-    private void checkCardOwner(UUID searchCardId, Long userId) {
-        webClientBuilder.build().get()
-                .uri(reviewServiceUrl + "/api/v1/review/card/{searchCardId}/owner-check?userId={userId}", searchCardId,
-                        userId)
-                .retrieve().onStatus(HttpStatusCode::isError, cr -> Mono.error(new AccessDeniedException("권한 확인 실패")))
-                .bodyToMono(Boolean.class)
-                .map(isOwner -> {
-                    if (!isOwner) {
-                        throw new AccessDeniedException("접근 권한이 없습니다.");
-                    }
-                    return isOwner;
-                }).block();
     }
 
     private record AnalysisPoint(Long id, String name, double lat, double lon) {

--- a/analysis/src/main/java/ziply/analysis/service/SafetyNewsService.java
+++ b/analysis/src/main/java/ziply/analysis/service/SafetyNewsService.java
@@ -2,7 +2,6 @@ package ziply.analysis.service;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -12,27 +11,20 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 import ziply.analysis.domain.HouseAnalysis;
 import ziply.analysis.domain.SafetyNews;
 import ziply.analysis.dto.response.SafetyNewsResponse;
 import ziply.analysis.dto.response.SafetyNewsResponse.NewsItem;
 import ziply.analysis.repository.HouseRouteAnalysisRepository;
 import ziply.analysis.repository.SafetyNewsRepository;
-
-import org.springframework.beans.factory.annotation.Value;
+import ziply.analysis.util.HouseLabelMapper;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SafetyNewsService {
-
-    private static final int DEFAULT_PAGE_SIZE = 10;
 
     private static final Map<Integer, String> LEVEL_NAME = Map.of(
         1, "생활 불편 / 무질서",
@@ -42,10 +34,8 @@ public class SafetyNewsService {
 
     private final SafetyNewsRepository safetyNewsRepository;
     private final HouseRouteAnalysisRepository routeAnalysisRepository;
-    private final WebClient.Builder webClientBuilder;
-
-    @Value("${services.review.url:http://review-service:8080}")
-    private String reviewServiceUrl;
+    private final CardOwnershipValidator cardOwnershipValidator;
+    private final HouseLabelMapper houseLabelMapper;
 
     /**
      * 탐색카드 내 각 집의 동(regionName) 기반으로 치안 뉴스를 집계하여 반환.
@@ -56,24 +46,21 @@ public class SafetyNewsService {
      */
     @Transactional(readOnly = true)
     public List<SafetyNewsResponse> getNewsAnalysis(UUID searchCardId, Long userId, int period, int page, int size) {
-        checkCardOwner(searchCardId, userId);
+        cardOwnershipValidator.validate(searchCardId, userId);
 
-        // HouseAnalysis에서 searchCard 소속 집 목록 및 regionName 조회
         List<HouseAnalysis> allData = routeAnalysisRepository.findBySearchCardId(searchCardId);
         if (allData.isEmpty()) {
             return Collections.emptyList();
         }
 
-        // houseId → label (A, B, C...)
-        Map<Long, String> labelMap = buildLabelMap(allData);
+        Map<Long, String> labelMap = houseLabelMapper.build(allData);
 
-        // houseId → regionName (중복 제거, 첫 번째 값 사용)
         Map<Long, String> regionMap = allData.stream()
                 .filter(ha -> ha.getRegionName() != null)
                 .collect(Collectors.toMap(
                         HouseAnalysis::getHouseId,
                         HouseAnalysis::getRegionName,
-                        (a, b) -> a   // 중복 시 첫 번째 유지
+                        (a, b) -> a
                 ));
 
         LocalDateTime since = LocalDateTime.now().minusMonths(period);
@@ -87,17 +74,16 @@ public class SafetyNewsService {
 
                     if (regionName == null || regionName.isBlank()) {
                         log.warn("[SafetyNews] houseId={} regionName 없음, 집계 불가", houseId);
-                        return buildEmptyResponse(houseId, label, period);
+                        return buildEmptyResponse(label);
                     }
 
-                    return buildNewsResponse(houseId, label, regionName, period, since, page, size);
+                    return buildNewsResponse(label, regionName, period, since, page, size);
                 })
                 .collect(Collectors.toList());
     }
 
-    private SafetyNewsResponse buildNewsResponse(Long houseId, String label, String regionName,
+    private SafetyNewsResponse buildNewsResponse(String label, String regionName,
                                                   int period, LocalDateTime since, int page, int size) {
-        // 레벨 카운트는 전체 조회
         List<SafetyNews> allNews = safetyNewsRepository.findByRegionAndPeriod(regionName, since);
         int level1 = 0, level2 = 0, level3 = 0;
         for (SafetyNews n : allNews) {
@@ -109,7 +95,6 @@ public class SafetyNewsService {
         }
         int total = level1 + level2 + level3;
 
-        // 페이지네이션 뉴스 조회 (최신순)
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "publishedAt"));
         Page<SafetyNews> newsPage = safetyNewsRepository.findByRegionAndPeriodPageable(regionName, since, pageable);
 
@@ -141,7 +126,7 @@ public class SafetyNewsService {
                 .build();
     }
 
-    private SafetyNewsResponse buildEmptyResponse(Long houseId, String label, int period) {
+    private SafetyNewsResponse buildEmptyResponse(String label) {
         return SafetyNewsResponse.builder()
                 .label(label)
                 .regionName(null)
@@ -170,30 +155,5 @@ public class SafetyNewsService {
         }
 
         return sb.toString();
-    }
-
-    private Map<Long, String> buildLabelMap(List<HouseAnalysis> allData) {
-        List<Long> sortedIds = allData.stream()
-                .map(HouseAnalysis::getHouseId)
-                .distinct().sorted().toList();
-        Map<Long, String> map = new HashMap<>();
-        for (int i = 0; i < sortedIds.size(); i++) {
-            map.put(sortedIds.get(i), String.valueOf((char) ('A' + i)));
-        }
-        return map;
-    }
-
-    private void checkCardOwner(UUID searchCardId, Long userId) {
-        webClientBuilder.build().get()
-                .uri(reviewServiceUrl + "/api/v1/review/card/{searchCardId}/owner-check?userId={userId}",
-                        searchCardId, userId)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError,
-                        cr -> Mono.error(new AccessDeniedException("권한 확인 실패")))
-                .bodyToMono(Boolean.class)
-                .map(isOwner -> {
-                    if (!isOwner) throw new AccessDeniedException("접근 권한이 없습니다.");
-                    return isOwner;
-                }).block();
     }
 }

--- a/analysis/src/main/java/ziply/analysis/service/SafetyNewsService.java
+++ b/analysis/src/main/java/ziply/analysis/service/SafetyNewsService.java
@@ -43,9 +43,13 @@ public class SafetyNewsService {
      * @param searchCardId 탐색카드 ID
      * @param userId       요청 사용자 ID (권한 확인)
      * @param period       조회 기간 (개월): 3, 6, 12
+     * @param level        뉴스 레벨 (1: 생활 불편, 2: 안전 불안, 3: 신변 위협)
+     * @param page         페이지 번호 (0-based)
+     * @param size         페이지당 항목 수
      */
     @Transactional(readOnly = true)
-    public List<SafetyNewsResponse> getNewsAnalysis(UUID searchCardId, Long userId, int period, int page, int size) {
+    public List<SafetyNewsResponse> getNewsAnalysis(UUID searchCardId, Long userId,
+                                                     int period, int level, int page, int size) {
         cardOwnershipValidator.validate(searchCardId, userId);
 
         List<HouseAnalysis> allData = routeAnalysisRepository.findBySearchCardId(searchCardId);
@@ -77,13 +81,14 @@ public class SafetyNewsService {
                         return buildEmptyResponse(label);
                     }
 
-                    return buildNewsResponse(label, regionName, period, since, page, size);
+                    return buildNewsResponse(label, regionName, period, since, level, page, size);
                 })
                 .collect(Collectors.toList());
     }
 
     private SafetyNewsResponse buildNewsResponse(String label, String regionName,
-                                                  int period, LocalDateTime since, int page, int size) {
+                                                  int period, LocalDateTime since,
+                                                  int level, int page, int size) {
         List<SafetyNews> allNews = safetyNewsRepository.findByRegionAndPeriod(regionName, since);
         int level1 = 0, level2 = 0, level3 = 0;
         for (SafetyNews n : allNews) {
@@ -96,18 +101,7 @@ public class SafetyNewsService {
         int total = level1 + level2 + level3;
 
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "publishedAt"));
-        Page<SafetyNews> newsPage = safetyNewsRepository.findByRegionAndPeriodPageable(regionName, since, pageable);
-
-        List<NewsItem> recent = newsPage.getContent().stream()
-                .map(n -> NewsItem.builder()
-                        .title(n.getTitle())
-                        .categoryLevel(LEVEL_NAME.getOrDefault(n.getCategoryLevel(), "알 수 없음"))
-                        .categoryTag(n.getCategoryTag())
-                        .publishedAt(n.getPublishedAt().toLocalDate())
-                        .contentUrl(n.getContentUrl())
-                        .summary(n.getSummary())
-                        .build())
-                .collect(Collectors.toList());
+        Page<SafetyNews> newsPage = safetyNewsRepository.findByRegionAndPeriodAndLevel(regionName, since, level, pageable);
 
         String message = buildMessage(regionName, period, level1, level2, level3, total);
 
@@ -118,12 +112,25 @@ public class SafetyNewsService {
                 .level2Count(level2)
                 .level3Count(level3)
                 .message(message)
-                .recentNews(recent)
+                .news(toNewsItems(newsPage))
                 .page(newsPage.getNumber())
                 .size(newsPage.getSize())
                 .totalCount(newsPage.getTotalElements())
                 .totalPages(newsPage.getTotalPages())
                 .build();
+    }
+
+    private List<NewsItem> toNewsItems(Page<SafetyNews> newsPage) {
+        return newsPage.getContent().stream()
+                .map(n -> NewsItem.builder()
+                        .title(n.getTitle())
+                        .categoryLevel(LEVEL_NAME.getOrDefault(n.getCategoryLevel(), "알 수 없음"))
+                        .categoryTag(n.getCategoryTag())
+                        .publishedAt(n.getPublishedAt().toLocalDate())
+                        .contentUrl(n.getContentUrl())
+                        .summary(n.getSummary())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     private SafetyNewsResponse buildEmptyResponse(String label) {
@@ -132,7 +139,7 @@ public class SafetyNewsService {
                 .regionName(null)
                 .level1Count(0).level2Count(0).level3Count(0)
                 .message("이 집의 지역 정보를 확인할 수 없어 치안 뉴스를 불러오지 못했어요.")
-                .recentNews(Collections.emptyList())
+                .news(Collections.emptyList())
                 .page(0).size(0).totalCount(0).totalPages(0)
                 .build();
     }

--- a/analysis/src/main/java/ziply/analysis/util/HouseLabelMapper.java
+++ b/analysis/src/main/java/ziply/analysis/util/HouseLabelMapper.java
@@ -1,0 +1,22 @@
+package ziply.analysis.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import ziply.analysis.domain.HouseAnalysis;
+
+@Component
+public class HouseLabelMapper {
+
+    public Map<Long, String> build(List<HouseAnalysis> allData) {
+        List<Long> sortedIds = allData.stream()
+                .map(HouseAnalysis::getHouseId)
+                .distinct().sorted().toList();
+        Map<Long, String> map = new HashMap<>();
+        for (int i = 0; i < sortedIds.size(); i++) {
+            map.put(sortedIds.get(i), String.valueOf((char) ('A' + i)));
+        }
+        return map;
+    }
+}

--- a/analysis/src/test/java/ziply/analysis/service/RouteAnalysisServiceTest.java
+++ b/analysis/src/test/java/ziply/analysis/service/RouteAnalysisServiceTest.java
@@ -5,8 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,13 +16,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 import ziply.analysis.domain.HouseAnalysis;
 import ziply.analysis.dto.response.BasePointAnalysisDto;
 import ziply.analysis.dto.response.LifeScoreAnalysisResponse;
@@ -32,6 +28,7 @@ import ziply.analysis.event.HouseUpdatedEvent;
 import ziply.analysis.repository.HouseInfrastructureRepository;
 import ziply.analysis.repository.HouseRouteAnalysisRepository;
 import ziply.analysis.service.safety.SafetyScoringService;
+import ziply.analysis.util.HouseLabelMapper;
 
 @ExtendWith(MockitoExtension.class)
 class RouteAnalysisServiceTest {
@@ -48,10 +45,10 @@ class RouteAnalysisServiceTest {
     private NoiseScoringService noiseScoringService;
     @Mock
     private SafetyScoringService safetyScoringService;
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private WebClient.Builder webClientBuilder;
     @Mock
     private OdsayTransitProvider transitProvider;
+    @Mock
+    private CardOwnershipValidator cardOwnershipValidator;
 
     private RouteAnalysisService routeAnalysisService;
 
@@ -64,16 +61,15 @@ class RouteAnalysisServiceTest {
                 kakaoInfrastructureService,
                 noiseScoringService,
                 safetyScoringService,
-                webClientBuilder,
-                transitProvider
+                transitProvider,
+                cardOwnershipValidator,
+                new HouseLabelMapper()
         );
-        ReflectionTestUtils.setField(routeAnalysisService, "reviewServiceUrl", "http://review-service:8080");
     }
 
     @Test
     void getSearchCardDistanceAnalysisReturnsEmptyWhenNoData() {
         UUID searchCardId = UUID.randomUUID();
-        mockOwnerCheck(true);
         when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of());
 
         List<BasePointAnalysisDto> result = routeAnalysisService.getSearchCardDistanceAnalysis(searchCardId, 1L);
@@ -84,7 +80,6 @@ class RouteAnalysisServiceTest {
     @Test
     void getSearchCardDistanceAnalysisParsesTransitPaymentString() {
         UUID searchCardId = UUID.randomUUID();
-        mockOwnerCheck(true);
 
         HouseAnalysis houseA = HouseAnalysis.builder()
                 .searchCardId(searchCardId)
@@ -122,7 +117,8 @@ class RouteAnalysisServiceTest {
     @Test
     void getSearchCardDistanceAnalysisThrowsWhenUserIsNotOwner() {
         UUID searchCardId = UUID.randomUUID();
-        mockOwnerCheck(false);
+        doThrow(new AccessDeniedException("접근 권한이 없습니다."))
+                .when(cardOwnershipValidator).validate(searchCardId, 1L);
 
         assertThatThrownBy(() -> routeAnalysisService.getSearchCardDistanceAnalysis(searchCardId, 1L))
                 .isInstanceOf(AccessDeniedException.class);
@@ -149,7 +145,6 @@ class RouteAnalysisServiceTest {
     @Test
     void getLifeScoreAnalysisReturnsEmptyWhenNoData() {
         UUID searchCardId = UUID.randomUUID();
-        mockOwnerCheck(true);
         when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of());
 
         List<LifeScoreAnalysisResponse> result = routeAnalysisService.getLifeScoreAnalysis(searchCardId, 1L);
@@ -160,7 +155,6 @@ class RouteAnalysisServiceTest {
     @Test
     void getLifeScoreAnalysisUsesFallbackMessageWhenInfraMissing() {
         UUID searchCardId = UUID.randomUUID();
-        mockOwnerCheck(true);
 
         HouseAnalysis house = HouseAnalysis.builder()
                 .searchCardId(searchCardId)
@@ -181,7 +175,6 @@ class RouteAnalysisServiceTest {
     @Test
     void getSafetyAnalysisReturnsSortedByHouseId() {
         UUID searchCardId = UUID.randomUUID();
-        mockOwnerCheck(true);
 
         HouseAnalysis highId = HouseAnalysis.builder()
                 .searchCardId(searchCardId)
@@ -208,15 +201,5 @@ class RouteAnalysisServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getHouseId()).isEqualTo(10L);
         assertThat(result.get(1).getHouseId()).isEqualTo(20L);
-    }
-
-    private void mockOwnerCheck(boolean isOwner) {
-        when(webClientBuilder.build()
-                .get()
-                .uri(anyString(), any(), any())
-                .retrieve()
-                .onStatus(any(), any())
-                .bodyToMono(eq(Boolean.class)))
-                .thenReturn(Mono.just(isOwner));
     }
 }

--- a/analysis/src/test/java/ziply/analysis/service/SafetyNewsServiceTest.java
+++ b/analysis/src/test/java/ziply/analysis/service/SafetyNewsServiceTest.java
@@ -1,0 +1,289 @@
+package ziply.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+import ziply.analysis.domain.HouseAnalysis;
+import ziply.analysis.domain.SafetyNews;
+import ziply.analysis.dto.response.SafetyNewsResponse;
+import ziply.analysis.repository.HouseRouteAnalysisRepository;
+import ziply.analysis.repository.SafetyNewsRepository;
+import ziply.analysis.util.HouseLabelMapper;
+
+@ExtendWith(MockitoExtension.class)
+class SafetyNewsServiceTest {
+
+    @Mock
+    private SafetyNewsRepository safetyNewsRepository;
+    @Mock
+    private HouseRouteAnalysisRepository routeAnalysisRepository;
+    @Mock
+    private CardOwnershipValidator cardOwnershipValidator;
+
+    private SafetyNewsService safetyNewsService;
+
+    @BeforeEach
+    void setUp() {
+        safetyNewsService = new SafetyNewsService(
+                safetyNewsRepository,
+                routeAnalysisRepository,
+                cardOwnershipValidator,
+                new HouseLabelMapper()
+        );
+    }
+
+    // ───────────── 권한 확인 ─────────────
+
+    @Test
+    void getNewsAnalysis_ThrowsWhenUserIsNotOwner() {
+        UUID searchCardId = UUID.randomUUID();
+        doThrow(new AccessDeniedException("접근 권한이 없습니다."))
+                .when(cardOwnershipValidator).validate(searchCardId, 1L);
+
+        assertThatThrownBy(() -> safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    // ───────────── 빈 데이터 ─────────────
+
+    @Test
+    void getNewsAnalysis_ReturnsEmptyWhenNoHouseData() {
+        UUID searchCardId = UUID.randomUUID();
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of());
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getNewsAnalysis_ReturnsEmptyResponseWhenRegionNameIsNull() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis house = HouseAnalysis.builder()
+                .searchCardId(searchCardId)
+                .houseId(10L)
+                .basePointId(1L)
+                .regionName(null)
+                .build();
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(house));
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        assertThat(result).hasSize(1);
+        SafetyNewsResponse resp = result.get(0);
+        assertThat(resp.getLabel()).isEqualTo("A");
+        assertThat(resp.getRegionName()).isNull();
+        assertThat(resp.getLevel1Count()).isZero();
+        assertThat(resp.getLevel2Count()).isZero();
+        assertThat(resp.getLevel3Count()).isZero();
+        assertThat(resp.getRecentNews()).isEmpty();
+        assertThat(resp.getMessage()).contains("지역 정보를 확인할 수 없어");
+    }
+
+    // ───────────── 레벨 카운트 ─────────────
+
+    @Test
+    void getNewsAnalysis_CountsNewsByLevel() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis house = makeHouse(searchCardId, 10L, "상도동");
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(house));
+
+        SafetyNews n1 = makeNews(1, "생활 소음", LocalDateTime.now().minusDays(1));
+        SafetyNews n2 = makeNews(1, "쓰레기 무단투기", LocalDateTime.now().minusDays(2));
+        SafetyNews n3 = makeNews(2, "절도", LocalDateTime.now().minusDays(3));
+        SafetyNews n4 = makeNews(3, "폭행", LocalDateTime.now().minusDays(4));
+        List<SafetyNews> allNews = List.of(n1, n2, n3, n4);
+
+        when(safetyNewsRepository.findByRegionAndPeriod(eq("상도동"), any(LocalDateTime.class)))
+                .thenReturn(allNews);
+        when(safetyNewsRepository.findByRegionAndPeriodPageable(eq("상도동"), any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(allNews));
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        SafetyNewsResponse resp = result.get(0);
+        assertThat(resp.getLevel1Count()).isEqualTo(2);
+        assertThat(resp.getLevel2Count()).isEqualTo(1);
+        assertThat(resp.getLevel3Count()).isEqualTo(1);
+    }
+
+    // ───────────── NewsItem 변환 ─────────────
+
+    @Test
+    void getNewsAnalysis_MapsNewsItemFieldsCorrectly() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis house = makeHouse(searchCardId, 10L, "상도동");
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(house));
+
+        LocalDateTime published = LocalDateTime.of(2026, 1, 15, 9, 0);
+        SafetyNews news = makeNews(2, "재산 범죄", published);
+        ReflectionTestUtils.setField(news, "title", "상도동 절도 사건 발생");
+        ReflectionTestUtils.setField(news, "contentUrl", "http://news.example.com/123");
+        ReflectionTestUtils.setField(news, "summary", "상도동에서 절도 사건이 발생했습니다.");
+
+        when(safetyNewsRepository.findByRegionAndPeriod(anyString(), any())).thenReturn(List.of(news));
+        when(safetyNewsRepository.findByRegionAndPeriodPageable(anyString(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(news)));
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        SafetyNewsResponse.NewsItem item = result.get(0).getRecentNews().get(0);
+        assertThat(item.getTitle()).isEqualTo("상도동 절도 사건 발생");
+        assertThat(item.getCategoryLevel()).isEqualTo("안전 불안 / 재산 위협");
+        assertThat(item.getCategoryTag()).isEqualTo("재산 범죄");
+        assertThat(item.getPublishedAt()).isEqualTo(LocalDate.of(2026, 1, 15));
+        assertThat(item.getContentUrl()).isEqualTo("http://news.example.com/123");
+        assertThat(item.getSummary()).isEqualTo("상도동에서 절도 사건이 발생했습니다.");
+    }
+
+    // ───────────── 페이지네이션 메타 ─────────────
+
+    @Test
+    void getNewsAnalysis_ReflectsPageMetaInResponse() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis house = makeHouse(searchCardId, 10L, "상도동");
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(house));
+
+        SafetyNews n = makeNews(1, "소음", LocalDateTime.now().minusDays(1));
+        List<SafetyNews> pageContent = List.of(n);
+
+        when(safetyNewsRepository.findByRegionAndPeriod(anyString(), any())).thenReturn(pageContent);
+        Page<SafetyNews> page = new PageImpl<>(pageContent,
+                org.springframework.data.domain.PageRequest.of(1, 5), 15);
+        when(safetyNewsRepository.findByRegionAndPeriodPageable(anyString(), any(), any()))
+                .thenReturn(page);
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 1, 5);
+
+        SafetyNewsResponse resp = result.get(0);
+        assertThat(resp.getPage()).isEqualTo(1);
+        assertThat(resp.getSize()).isEqualTo(5);
+        assertThat(resp.getTotalCount()).isEqualTo(15);
+        assertThat(resp.getTotalPages()).isEqualTo(3);
+    }
+
+    // ───────────── 메시지 ─────────────
+
+    @Test
+    void getNewsAnalysis_MessageContainsLevel3Warning() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis house = makeHouse(searchCardId, 10L, "상도동");
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(house));
+
+        SafetyNews n = makeNews(3, "강력 범죄", LocalDateTime.now().minusDays(1));
+        when(safetyNewsRepository.findByRegionAndPeriod(anyString(), any())).thenReturn(List.of(n));
+        when(safetyNewsRepository.findByRegionAndPeriodPageable(anyString(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(n)));
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        assertThat(result.get(0).getMessage()).contains("신변 위협").contains("주의하세요");
+    }
+
+    @Test
+    void getNewsAnalysis_MessageContainsLevel2Summary() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis house = makeHouse(searchCardId, 10L, "상도동");
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(house));
+
+        SafetyNews n1 = makeNews(2, "절도", LocalDateTime.now().minusDays(1));
+        SafetyNews n2 = makeNews(1, "소음", LocalDateTime.now().minusDays(2));
+        List<SafetyNews> news = List.of(n1, n2);
+
+        when(safetyNewsRepository.findByRegionAndPeriod(anyString(), any())).thenReturn(news);
+        when(safetyNewsRepository.findByRegionAndPeriodPageable(anyString(), any(), any()))
+                .thenReturn(new PageImpl<>(news));
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        assertThat(result.get(0).getMessage()).contains("안전 불안").contains("생활 불편");
+    }
+
+    @Test
+    void getNewsAnalysis_MessageIndicatesNoNewsWhenEmpty() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis house = makeHouse(searchCardId, 10L, "상도동");
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(house));
+
+        when(safetyNewsRepository.findByRegionAndPeriod(anyString(), any())).thenReturn(List.of());
+        when(safetyNewsRepository.findByRegionAndPeriodPageable(anyString(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        assertThat(result.get(0).getMessage()).contains("수집된 치안 관련 뉴스가 없어요");
+    }
+
+    // ───────────── 레이블 순서 ─────────────
+
+    @Test
+    void getNewsAnalysis_AssignsLabelsInHouseIdOrder() {
+        UUID searchCardId = UUID.randomUUID();
+
+        HouseAnalysis h1 = makeHouse(searchCardId, 30L, "상도동");
+        HouseAnalysis h2 = makeHouse(searchCardId, 10L, "동작동");
+        HouseAnalysis h3 = makeHouse(searchCardId, 20L, "노량진동");
+        when(routeAnalysisRepository.findBySearchCardId(searchCardId)).thenReturn(List.of(h1, h2, h3));
+
+        when(safetyNewsRepository.findByRegionAndPeriod(anyString(), any())).thenReturn(List.of());
+        when(safetyNewsRepository.findByRegionAndPeriodPageable(anyString(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        List<SafetyNewsResponse> result = safetyNewsService.getNewsAnalysis(searchCardId, 1L, 3, 0, 10);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getLabel()).isEqualTo("A");
+        assertThat(result.get(1).getLabel()).isEqualTo("B");
+        assertThat(result.get(2).getLabel()).isEqualTo("C");
+    }
+
+    // ───────────── 헬퍼 ─────────────
+
+    private HouseAnalysis makeHouse(UUID searchCardId, Long houseId, String regionName) {
+        return HouseAnalysis.builder()
+                .searchCardId(searchCardId)
+                .houseId(houseId)
+                .basePointId(1L)
+                .regionName(regionName)
+                .build();
+    }
+
+    private SafetyNews makeNews(int level, String tag, LocalDateTime publishedAt) {
+        SafetyNews news = new SafetyNews();
+        ReflectionTestUtils.setField(news, "id", 1L);
+        ReflectionTestUtils.setField(news, "title", "테스트 뉴스 제목");
+        ReflectionTestUtils.setField(news, "contentUrl", "http://news.example.com/1");
+        ReflectionTestUtils.setField(news, "categoryLevel", level);
+        ReflectionTestUtils.setField(news, "categoryTag", tag);
+        ReflectionTestUtils.setField(news, "regionName", "상도동");
+        ReflectionTestUtils.setField(news, "publishedAt", publishedAt);
+        ReflectionTestUtils.setField(news, "summary", "요약 내용");
+        return news;
+    }
+}


### PR DESCRIPTION
recentNews 단일 목록을 level 파라미터로 분리하여
탭 UI에서 레벨별 독립 페이지네이션 지원.
size 파라미터 제거 후 10건으로 고정.